### PR TITLE
add local tests and remove useless error handle

### DIFF
--- a/src/bot/locale/__tests__/english.spec.js
+++ b/src/bot/locale/__tests__/english.spec.js
@@ -1,0 +1,5 @@
+import english from '../english';
+
+it('should be defined', () => {
+  expect(english).toBeDefined();
+});

--- a/src/bot/locale/__tests__/index.spec.js
+++ b/src/bot/locale/__tests__/index.spec.js
@@ -1,0 +1,24 @@
+import locale from '../../locale';
+import traditionalChinese from '../traditionalChinese';
+import english from '../english';
+
+describe('locale', () => {
+  it('should be defined', () => {
+    expect(locale).toBeDefined();
+  });
+
+  it('should return traditionalChinese as default', () => {
+    const language = locale();
+    expect(language).toEqual(traditionalChinese);
+  });
+
+  it('should return traditionalChinese', () => {
+    const language = locale('zh-TW');
+    expect(language).toEqual(traditionalChinese);
+  });
+
+  it('should return english', () => {
+    const language = locale('en');
+    expect(language).toEqual(english);
+  });
+});

--- a/src/bot/locale/__tests__/traditionalChinese.spec.js
+++ b/src/bot/locale/__tests__/traditionalChinese.spec.js
@@ -1,0 +1,5 @@
+import traditionalChinese from '../traditionalChinese';
+
+it('should be defined', () => {
+  expect(traditionalChinese).toBeDefined();
+});

--- a/src/routes/bot.js
+++ b/src/routes/bot.js
@@ -12,11 +12,6 @@ botRouter.use(bodyParser());
 const requestHandler = bot.createRequestHandler();
 
 botRouter.post(`/bot${botToken}`, async ({ request, response }) => {
-  if (!request.body) {
-    throw new Error(
-      'createMiddleware(): Missing body parser. Use `koa-bodyparser` or other similar package before this middleware.'
-    );
-  }
   await requestHandler(request.body);
   response.status = 200;
 });


### PR DESCRIPTION
`request.body` 那邊因為我們絕對已經有 `.use(bodyParser)`，所以我覺得多判斷沒意義就刪了
  
<img width="761" alt="screen shot 2017-08-12 at 11 19 01 pm" src="https://user-images.githubusercontent.com/12113222/29241854-e015f63c-7fb4-11e7-8825-257bf7c62eb3.png">
