### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ $ yarn run dev
 $ yarn run start
 ```
 
-## Dokcer
-> Before docker run, remember to run ealsticsearch and mongo containers
+## Docker
+> Before docker run, remember to run elasticsearch and mongo containers
 
 ### build
 ```js


### PR DESCRIPTION
我發現 README.md 裡面有的 Docker 跟 elasticsearch 好像打錯了，就來發個 pr 把它修了。